### PR TITLE
Implement styled primitives classes declaration

### DIFF
--- a/examples/simple/index.jsx
+++ b/examples/simple/index.jsx
@@ -14,17 +14,21 @@ const styled = Styled({
   content: {
     padding: ({ padding }) => `${padding}px`,
   },
-  section__content: {
-    color: 'red',
+  section: {
+    _content: {
+      color: 'red',
+      composes: '$content',
+    },
   },
   text: {
     color: 'green',
   },
   h1: {
     color: 'red',
-  },
-  h1__text: {
-    composes: '$text',
+
+    _text: {
+      composes: '$text',
+    },
   },
   p: {
     border: '1px solid black',

--- a/examples/simple/index.jsx
+++ b/examples/simple/index.jsx
@@ -14,11 +14,21 @@ const styled = Styled({
   content: {
     padding: ({ padding }) => `${padding}px`,
   },
-  h1: {
+  section__content: {
     color: 'red',
   },
   text: {
     color: 'green',
+  },
+  h1: {
+    color: 'red',
+  },
+  h1__text: {
+    composes: '$text',
+  },
+  p: {
+    border: '1px solid black',
+    composes: '$text $h1'.split(' '),
   },
   button: {
     margin: ({ margin = 0 }) => `${margin}px`,
@@ -27,24 +37,24 @@ const styled = Styled({
 
 const Header = () => (
   <styled.header>
-    <styled.h1>Styled JSS simple example</styled.h1>
+    <styled.h1>Just H1</styled.h1>
+    <styled.h1.text>Force test</styled.h1.text>
   </styled.header>
 )
 
 const Content = () => (
-  <styled.section
-    composes="content"
+  <styled.section.content
     attrs={{
       'data-name': 'content',
       ref: (c) => { console.log('SECTION REF', c) },
     }}
     padding={20}
   >
-    <styled.p composes="text">check this out</styled.p>
+    <styled.p>compose multiple classes test</styled.p>
 
-    <styled.button>first button</styled.button>
-    <styled.button margin={10}>second button</styled.button>
-  </styled.section>
+    <styled.button>primitive test</styled.button>
+    <styled.button margin={10}>dynamic primitive test</styled.button>
+  </styled.section.content>
 )
 
 const App = () => (

--- a/src/dom-elements.js
+++ b/src/dom-elements.js
@@ -1,6 +1,6 @@
 // Thanks to ReactDOMFactories and styled-components for this handy list ;)
 
-export default [
+export default new Set([
   'a',
   'abbr',
   'address',
@@ -135,4 +135,4 @@ export default [
   'svg',
   'text',
   'tspan',
-]
+])

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import injectSheet from 'react-jss'
 import preset from 'jss-preset-default'
 
 import domElements from './dom-elements'
-import prepareStyles from './prepare-styles'
+import prepareStyles, { styledClassFlag } from './prepare-styles'
 
 
 const JSS = createJSS(preset())
@@ -41,7 +41,7 @@ export const prepareStyled = ({ jss = JSS } = {}) => (styles) => {
   return Object
     .keys(stylesPrepared)
     .reduce((acc, key) => {
-      const [elem, name] = key.split('_')
+      const [elem, name] = key.split(styledClassFlag)
 
       const isDomeElem = domElements.has(elem)
 

--- a/src/prepare-styles.js
+++ b/src/prepare-styles.js
@@ -1,13 +1,17 @@
+export const styledClassFlag = '_'
+
+
 export const pullOutStylesReducerByElem = elem => (elemStyles, [prop, val]) => ({
   ...elemStyles,
-  ...prop.startsWith('_')
-    ? { [elem + prop]: val }
+  ...prop.startsWith(styledClassFlag)
+    ? { [elem + prop]: { ...val, composes: [`$${elem}`].concat(val.composes || []) } }
     : { [elem]: { ...elemStyles[elem], [prop]: val } },
 })
 
 export const pullOutStyles = (elem, styles) => Object
   .entries(styles)
   .reduce(pullOutStylesReducerByElem(elem), { [elem]: {} })
+
 
 export const prepareStylesReducer = (acc, [elem, styles]) => ({
   ...acc,

--- a/src/prepare-styles.js
+++ b/src/prepare-styles.js
@@ -1,0 +1,19 @@
+export const pullOutStylesReducerByElem = elem => (elemStyles, [prop, val]) => ({
+  ...elemStyles,
+  ...prop.startsWith('_')
+    ? { [elem + prop]: val }
+    : { [elem]: { ...elemStyles[elem], [prop]: val } },
+})
+
+export const pullOutStyles = (elem, styles) => Object
+  .entries(styles)
+  .reduce(pullOutStylesReducerByElem(elem), { [elem]: {} })
+
+export const prepareStylesReducer = (acc, [elem, styles]) => ({
+  ...acc,
+  ...pullOutStyles(elem, styles),
+})
+
+export default styles => Object
+  .entries(styles)
+  .reduce(prepareStylesReducer, {})

--- a/src/tests/App.jsx
+++ b/src/tests/App.jsx
@@ -13,17 +13,20 @@ const styled = Styled({
   content: {
     padding: ({ padding }) => `${padding}px`,
   },
-  section__content: {
-    color: 'red',
+  section: {
+    _content: {
+      color: 'red',
+    },
   },
   text: {
     color: 'green',
   },
   h1: {
     color: 'red',
-  },
-  h1__text: {
-    composes: '$text',
+
+    _text: {
+      composes: '$text',
+    },
   },
   p: {
     border: '1px solid black',

--- a/src/tests/App.jsx
+++ b/src/tests/App.jsx
@@ -13,14 +13,21 @@ const styled = Styled({
   content: {
     padding: ({ padding }) => `${padding}px`,
   },
-  h1: {
+  section__content: {
     color: 'red',
-  },
-  p: {
-    border: '1px solid black',
   },
   text: {
     color: 'green',
+  },
+  h1: {
+    color: 'red',
+  },
+  h1__text: {
+    composes: '$text',
+  },
+  p: {
+    border: '1px solid black',
+    composes: '$text $h1'.split(' '),
   },
   button: {
     margin: ({ margin = 0 }) => `${margin}px`,
@@ -30,23 +37,22 @@ const styled = Styled({
 const Header = () => (
   <styled.header>
     <styled.h1>Just H1</styled.h1>
-    <styled.h1 force composes="text">Force test</styled.h1>
+    <styled.h1.text>Force test</styled.h1.text>
   </styled.header>
 )
 
 const Content = () => (
-  <styled.section
-    composes="content"
+  <styled.section.content
     attrs={{
       'data-name': 'content',
     }}
     padding={20}
   >
-    <styled.p composes="text h1">compose multiple classes test</styled.p>
+    <styled.p>compose multiple classes test</styled.p>
 
     <styled.button>primitive test</styled.button>
     <styled.button margin={10}>dynamic primitive test</styled.button>
-  </styled.section>
+  </styled.section.content>
 )
 
 export default () => (

--- a/src/tests/__snapshots__/index.spec.jsx.snap
+++ b/src/tests/__snapshots__/index.spec.jsx.snap
@@ -4,27 +4,27 @@ exports[`test renders correctly 1`] = `
   <header
     className="header-0-1">
     <h1
-      className="h1-0-3">
+      className="h1-0-5">
       Just H1
     </h1>
     <h1
-      className="text-0-5">
+      className="h1__text-0-6 text-0-4">
       Force test
     </h1>
   </header>
   <section
-    className="content-0-14 content-0-9"
+    className="section__content-0-3"
     data-name="content">
     <p
-      className="text-0-5 h1-0-3 p-0-4">
+      className="p-0-7 text-0-4 h1-0-5">
       compose multiple classes test
     </p>
     <button
-      className="button-0-6">
+      className="button-0-8">
       primitive test
     </button>
     <button
-      className="button-0-24 button-0-22">
+      className="button-0-30 button-0-28">
       dynamic primitive test
     </button>
   </section>

--- a/src/tests/__snapshots__/index.spec.jsx.snap
+++ b/src/tests/__snapshots__/index.spec.jsx.snap
@@ -4,27 +4,27 @@ exports[`test renders correctly 1`] = `
   <header
     className="header-0-1">
     <h1
-      className="h1-0-5">
+      className="h1-0-6">
       Just H1
     </h1>
     <h1
-      className="h1__text-0-6 text-0-4">
+      className="h1_text-0-7 h1-0-6 text-0-5">
       Force test
     </h1>
   </header>
   <section
-    className="section__content-0-3"
+    className="section_content-0-4 section-0-3"
     data-name="content">
     <p
-      className="p-0-7 text-0-4 h1-0-5">
+      className="p-0-8 text-0-5 h1-0-6">
       compose multiple classes test
     </p>
     <button
-      className="button-0-8">
+      className="button-0-9">
       primitive test
     </button>
     <button
-      className="button-0-30 button-0-28">
+      className="button-0-33 button-0-31">
       dynamic primitive test
     </button>
   </section>


### PR DESCRIPTION
**There are some questions:**
- how to declare classes for primitives
- how to compose these classes

**Current solution:**
- declare classes as underscored properties in primitives literals
- compose and redeclare primitive classes like `primitive_class`

for example:
```js
const styles = {
  button: {
    color: 'red',

    _normal: {
      padding: '30px',
    },

    _primary: {
      color: 'green',
      composes: '$button_normal'
    },
  }
}

const Button = ({ styled }) => (
  <styled.button.primary>text</styled.button.primary>
)
```
